### PR TITLE
Исправила брызги молока в секции about

### DIFF
--- a/src/sass/layout/_about.scss
+++ b/src/sass/layout/_about.scss
@@ -1,7 +1,9 @@
 .about {
     position: relative;
+    z-index: 1;
     background-color: var(--section-background);
     padding-top: 125px;
+    padding-bottom: 20px;
     
     @media screen and (max-width: 500px) {
         background-image: url('../images/mobile/milk-spalsh-mobile.png');
@@ -18,20 +20,12 @@
 
     @include screen('tablet') {
         padding-top: 130px;
+        padding-bottom: 33px;
     }
 
     @include screen('desktop') {
         padding-top: 125px;
-        background-image: url('../images/desktop/milk-splash-desktop.png');
-        background-repeat: no-repeat;
-        background-size: contain;
-        background-position: bottom -50% center;
-
-        @media screen and (min-device-pixel-ratio: 2),
-            screen and (min-resolution: 192dpi),
-            screen and (min-resolution: 2dppx){
-            background-image: url('../images/desktop/milk-splash-desktop@2x.png');
-        }
+        padding-bottom: 20px;
     }
 
     &-wrap {
@@ -40,28 +34,29 @@
         }
     }
 
-    // &::after {
-    //     content: '';
+    &::after {
+        content: '';
 
-    //     @include screen ('desktop') {
-    //         display: block;
-    //         position: absolute;
-    //         left: 0%;
-    //         bottom: -20%;
-    //         height: 534px;
-    //         width: 100%;
-    //         background-image: url('../images/desktop/milk-splash-desktop.png');
-    //         background-repeat: no-repeat;
-    //         background-size: cover;
-    //         // background-position: bottom center;
+        @include screen ('desktop') {
+            display: block;
+            position: absolute;
+            left: 0%;
+            bottom: -13%;
+            height: 534px;
+            width: 100%;
+            background-image: url('../images/desktop/milk-splash-desktop.png');
+            background-repeat: no-repeat;
+            background-size: contain;
+            background-position-x: center;
+            z-index: -1;
     
-    //         @media screen and (min-device-pixel-ratio: 2),
-    //             screen and (min-resolution: 192dpi),
-    //             screen and (min-resolution: 2dppx){
-    //             background-image: url('../images/desktop/milk-splash-desktop@2x.png');
-    //         }
-    //     }
-    // }
+            @media screen and (min-device-pixel-ratio: 2),
+                screen and (min-resolution: 192dpi),
+                screen and (min-resolution: 2dppx){
+                background-image: url('../images/desktop/milk-splash-desktop@2x.png');
+            }
+        }
+    }
 }
 
 .about-img {

--- a/src/sass/layout/_advantages.scss
+++ b/src/sass/layout/_advantages.scss
@@ -1,15 +1,15 @@
 // Падинги-топ пересмотреть учитывая все стили, вверху вылазит 6 рх и сверить с верхней секцией
 .advantages {
-  padding-top: 39px;
+  padding-top: 20px;
   padding-bottom: 97px;
   background-color: var(--section-background);
 
   @include screen('tablet') {
-    padding-top: 66px;
+    padding-top: 33px;
     padding-bottom: 140px;
   }
   @include screen('desktop') {
-    padding-top: 39px;
+    padding-top: 20px;
     padding-bottom: 139px;
   }
 }


### PR DESCRIPTION
1) Добавила псевдоэлемент на котором спозиционировала картинку с брызгами молока для десктопа через background image. 
- чтобы картинка не накладывалась на текст задала ей z-index -1, а самой  секции z-index 1
- картинке задан background-size: contain, поэтому она не растягивается шире заданного контейнера, если нужно, чтобы картинка была шире 1280px, можно просто поменять background-size: cover, но после 1580px она начинает выпадать за контентейнер
2) Поменяла падинги в секции about and advantages, сделала их равными между секциями.