### PR TITLE
Центрировала кнопку для секции абоут мобильной версии

### DIFF
--- a/src/sass/components/_button.scss
+++ b/src/sass/components/_button.scss
@@ -50,6 +50,11 @@
   }
 
   .about & {
+    @media screen and (max-width: 767px) {
+      margin-right: auto;
+      margin-left: auto;
+      display: block;
+    }
     min-width: 176px;
     @include font(14px, 18px);
 


### PR DESCRIPTION
Для дисплея до 767 писелей добавила на margin-right: auto, margin-left: auto, display: block, чтобы выровнять кнопу по центру для мобильной версии